### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle Project settings
 projectName = audit-log
-version=1.2.2-SNAPSHOT
+version=2.0.0-SNAPSHOT
 
 # XP App values
 appName = com.enonic.app.audit.log


### PR DESCRIPTION
## Summary
- Bump master to `2.0.0-SNAPSHOT` to start the XP 8 line.
- Add `releaseBranch:` block to the workflow listing `master` and `1.x` so the publish action treats both as release branches.
- The `1.x` maintenance branch has been created from tag `v1.2.1`. A companion PR against `1.x` adds the same `releaseBranch:` config so push events to that branch trigger publishing.

Pattern follows [app-booster](https://github.com/enonic/app-booster).

## Test plan
- [ ] CI green on this branch
- [ ] After merge, `enonic/release-tools/build-and-publish` runs cleanly on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)