### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,107 +1,29 @@
 name: Gradle Build
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
+  release:
     runs-on: ubuntu-latest
 
-    needs: release_notes
-    if: always()
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v2
+      - uses: enonic/release-tools/release@master
         with:
-          java-version: 11
-          distribution: 'adopt'
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - run: ./gradlew build -Pcom.enonic.xp.app.production=true
-
-      - uses: codecov/codecov-action@v1
-        if: ${{!github.event.repository.private}}
-
-      ### PUBLISHING STEPS ###
-
-      - name: Get publishing variables
-        id: publish_vars
-        uses: enonic/release-tools/publish-vars@master
-        env:
-          PROPERTIES_PATH: './gradle.properties'
-          JAVA_HOME: ''
-
-      - name: Fail on bad config
-        if: steps.publish_vars.outputs.version == '' || steps.publish_vars.outputs.projectName == ''
-        run: exit 1
-
-      - name: Publish
-        if: ${{ !github.event.repository.private && github.ref == 'refs/heads/master' }}
-        run: ./gradlew publish -Pcom.enonic.xp.app.production=true -PrepoKey=${{ steps.publish_vars.outputs.repo }} -PrepoUser=${{ secrets.ARTIFACTORY_USERNAME }} -PrepoPassword=${{ secrets.ARTIFACTORY_PASSWORD }}
-
-      - name: Download changelog
-        if: steps.publish_vars.outputs.release == 'true'
-        uses: actions/download-artifact@v2
-        with:
-          name: changelog
-
-      - name: Create Release
-        if: steps.publish_vars.outputs.release == 'true'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.publish_vars.outputs.tag_name }}
-          body_path: changelog.md
-          prerelease: ${{ steps.publish_vars.outputs.prerelease == 'true' }}
-
-      - name: Write new snapshot version
-        if: steps.publish_vars.outputs.release == 'true'
-        uses: christian-draeger/write-properties@1.0.1
-        with:
-          path: './gradle.properties'
-          property: 'version'
-          value: ${{ steps.publish_vars.outputs.nextSnapshot }}
-
-      - name: Commit and push new version
-        if: steps.publish_vars.outputs.release == 'true'
-        uses: EndBug/add-and-commit@v7
-        with:
-          add: ./gradle.properties
-          message: 'Updated to next SNAPSHOT version'
-
-  release_notes:
-    runs-on: ubuntu-latest
-    if: "(github.ref == 'refs/heads/master')"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Get previous release tag
-        id: get_previous_release_tag
-        run: |
-          PREVIOUS_RELEASE_TAG=$(git tag --sort=-version:refname --merged | grep -E '^v([[:digit:]]+\.){2}[[:digit:]]+$' | head -1)
-          echo ::set-output name=previous_release_tag::$PREVIOUS_RELEASE_TAG
-      - name: Generate Release Notes
-        uses: enonic/release-tools/generate-changelog@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
-          PREVIOS_RELEASE_TAG: ${{ steps.get_previous_release_tag.outputs.previous_release_tag }}
-          OUTPUT_FILE: changelog.md
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: changelog
-          path: changelog.md
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace the legacy hand-rolled v1.2.1-era workflow on `1.x` with the modern `enonic/release-tools/build-and-publish` action used on master.
- Declare both `master` and `1.x` in the `releaseBranch:` block so push events to `1.x` trigger publishing — the action reads `releaseBranch:` from the branch's own workflow file.
- No version bump, no docgen change, no `versions.json` edit (master-only per the [app-booster](https://github.com/enonic/app-booster) reference).
- Companion to enonic/app-audit-log#780, which makes the same workflow change on master and bumps the master version to `2.0.0-SNAPSHOT`.

The `1.x` branch was created from tag `v1.2.1` (commit `5f4423f`) so that maintenance work can continue on the XP 7 line while master moves to XP 8.

## Test plan
- [ ] CI green on this branch
- [ ] After merge, an actual version-bump push to `1.x` triggers `enonic/release-tools/build-and-publish` with `release=='true'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)