### PR TITLE
Migrate to lib-asset #784

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     include libs.lib.thymeleaf
     include libs.lib.license
     include libs.lib.admin.ui
+    include libs.lib.asset
     devResources libs.lib.admin.ui
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,10 @@
 lib-thymeleaf = "3.0.0-SNAPSHOT"
 lib-license = "3.1.0"
 lib-admin-ui = "4.8.1"
+lib-asset = "2.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "lib-thymeleaf" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "lib-license" }
 lib-admin-ui = { module = "com.enonic.lib:lib-admin-ui", version.ref = "lib-admin-ui" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "lib-asset" }

--- a/src/main/resources/admin/tools/audit-log/audit-log.html
+++ b/src/main/resources/admin/tools/audit-log/audit-log.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audit log browser</title>
-    <link rel="stylesheet" type="text/css" data-th-href="|${assetsUrl}/admin/common/styles/lib.css|">
-    <link rel="stylesheet" type="text/css" data-th-href="|${assetsUrl}/styles/styles.css|" />
-    <script data-th-src="|${assetsUrl}/admin/common/js/lib.js|"></script>
+    <link rel="stylesheet" type="text/css" data-th-href="${adminCommonCssUrl}">
+    <link rel="stylesheet" type="text/css" data-th-href="${stylesUrl}" />
+    <script data-th-src="${adminCommonJsUrl}"></script>
     <script defer data-th-src="${launcherPath}" type="text/javascript"></script>
     <script data-th-inline="javascript">
         var CONFIG = {
@@ -17,13 +17,13 @@
             projects: /*[[${projects}]]*/,
             launcherUrl: /*[[${launcherUrl}]]*/, // Required for lanucher
             services: {}, // Workaround for i18nUrl BUG
-            appIconUrl: /*[[|${assetsUrl}/application.svg|]]*/,
-            icon: /*[[|${assetsUrl}/icons/entry.svg|]]*/,
+            appIconUrl: /*[[${appIconUrl}]]*/,
+            icon: /*[[${iconUrl}]]*/,
             licensedTo: /*[[${licenseText}]]*/,
         };
     </script>
     <!--/* Needs to be after config init since the script uses it */-->
-    <script data-th-src="|${assetsUrl}/js/main.js|"></script>
+    <script data-th-src="${mainJsUrl}"></script>
 </head>
 
 <body>

--- a/src/main/resources/admin/tools/audit-log/audit-log.js
+++ b/src/main/resources/admin/tools/audit-log/audit-log.js
@@ -1,6 +1,7 @@
 const thymeleaf = require("/lib/thymeleaf");
 const auditData = require("/lib/auditlog-data");
 const portal = require("/lib/xp/portal");
+const assetLib = require("/lib/enonic/asset");
 const adminLib = require("/lib/xp/admin");
 const project = require("/lib/xp/project");
 const licenseManager = require("/lib/license-manager");
@@ -24,12 +25,14 @@ exports.get = function () {
         type: "absolute",
     })
 
-    const assetsUrl = portal.assetUrl({
-        path: "",
-    });
-
     const model = {
-        assetsUrl,
+        adminCommonCssUrl: assetLib.assetUrl({ path: "admin/common/styles/lib.css" }),
+        adminCommonJsUrl: assetLib.assetUrl({ path: "admin/common/js/lib.js" }),
+        stylesUrl: assetLib.assetUrl({ path: "styles/styles.css" }),
+        mainJsUrl: assetLib.assetUrl({ path: "js/main.js" }),
+        licenseJsUrl: assetLib.assetUrl({ path: "js/license.js" }),
+        appIconUrl: assetLib.assetUrl({ path: "application.svg" }),
+        iconUrl: assetLib.assetUrl({ path: "icons/entry.svg" }),
         serviceUrl,
         licenseUrl,
         allUsers: users,

--- a/src/main/resources/admin/tools/audit-log/audit-log.yaml
+++ b/src/main/resources/admin/tools/audit-log/audit-log.yaml
@@ -4,3 +4,5 @@ description: "Browse system audit log"
 allow:
   - "role:com.enonic.app.audit.log.admin"
   - "role:system.admin"
+apis:
+  - "asset"

--- a/src/main/resources/admin/tools/audit-log/license.html
+++ b/src/main/resources/admin/tools/audit-log/license.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css" data-th-href="|${assetsUrl}/admin/common/styles/lib.css|">
-    <link rel="stylesheet" type="text/css" data-th-href="|${assetsUrl}/styles/styles.css|" />
-    <script data-th-src="|${assetsUrl}/js/license.js|"></script>
-    <script data-th-src="|${assetsUrl}/admin/common/js/lib.js|"></script>
+    <link rel="stylesheet" type="text/css" data-th-href="${adminCommonCssUrl}">
+    <link rel="stylesheet" type="text/css" data-th-href="${stylesUrl}" />
+    <script data-th-src="${licenseJsUrl}"></script>
+    <script data-th-src="${adminCommonJsUrl}"></script>
 
     <title>Upload a license</title>
     <script data-th-inline="javascript">


### PR DESCRIPTION
Closes #784.

Migrate the audit-log admin tool away from the deprecated `portal.assetUrl`
to `lib-asset`'s `assetUrl`. lib-asset is the right target here because the
only call site is in an admin-tool descriptor — lib-asset is valid for
Site, WebApp, and AdminTool contexts (lib-static would be needed only for
Universal API / Admin Extension / ID Provider).

## Wire-up

- `build.gradle`: `include libs.lib.asset`
- `gradle/libs.versions.toml`: add `lib-asset = "2.0.0-SNAPSHOT"`
- `src/main/resources/admin/tools/audit-log/audit-log.yaml`: register the bundled API with `apis: ["asset"]` so the admin tool can serve `/_/.../<app>:asset/...`

## Code change

The pre-migration code used `portal.assetUrl({path: ''})` to get a base URL
that templates concatenated with per-asset suffixes
(`${assetsUrl}/admin/common/styles/lib.css`, etc.). The empty-path idiom
doesn't carry over cleanly to lib-asset, so per the task guidance I rewrote
each consumer call to a real path:

- `audit-log.js`: compute one `assetLib.assetUrl({ path: ... })` per asset
  (admin-common css/js, styles.css, main.js, license.js, application.svg,
  icons/entry.svg).
- `audit-log.html` / `license.html`: reference the new model variables
  directly (no string concatenation).

Files touched:
- `build.gradle`
- `gradle/libs.versions.toml`
- `src/main/resources/admin/tools/audit-log/audit-log.yaml`
- `src/main/resources/admin/tools/audit-log/audit-log.js`
- `src/main/resources/admin/tools/audit-log/audit-log.html`
- `src/main/resources/admin/tools/audit-log/license.html`

## Test plan

- [x] `./gradlew build --refresh-dependencies` succeeds (clean build, lib-asset bundled into the jar).
- [x] Local E2E (XP 8.0.0-B4 in `/tmp`, app deployed to `home/deploy/`): admin tool URL `/admin/com.enonic.app.audit.log/audit-log` returns HTTP 200 with all asset references resolved to `/admin/com.enonic.app.audit.log/audit-log/_/com.enonic.app.audit.log:asset/<fingerprint>/<path>`.
- [x] Each of the 7 generated asset URLs (admin/common/styles/lib.css, admin/common/js/lib.js, styles/styles.css, js/main.js, js/license.js, application.svg, icons/entry.svg) returns HTTP 200 with the correct content-type and byte size.

Note: E2E required temporarily applying two unrelated XP-8 fixes (bump
`lib-license` to `4.0.0-SNAPSHOT` and stub the removed `adminLib.getLauncherPath()`/`getLauncherUrl()`) that are pre-existing master breakage — neither is included in this PR per the rule "don't bump unrelated libs". They will be fixed by separate PRs as referenced in issue #783.